### PR TITLE
Fix: Sign Up/Enter the Gateway Button

### DIFF
--- a/apps/website/components/organisms/navbar/navbar-avatar.tsx
+++ b/apps/website/components/organisms/navbar/navbar-avatar.tsx
@@ -18,7 +18,11 @@ import { AvatarFile } from '../../atoms/avatar-file';
 
 /* TODO: Refactor */
 
-export function NavBarAvatar() {
+type Props = {
+  hideProfile?: boolean;
+};
+
+export function NavBarAvatar({ hideProfile }: Props) {
   const { element, isOpen, onClose, onOpen, withOnClose } = useMenu();
   const router = useRouter();
 
@@ -85,12 +89,14 @@ export function NavBarAvatar() {
             Portuguese (Brazil)
           </MenuItem>
         </NestedMenuItem> */}
-        <MenuItem
-          key="view-profile"
-          onClick={() => router.push(ROUTES.MY_PROFILE)}
-        >
-          <Typography textAlign="center">Profile</Typography>
-        </MenuItem>
+        {!hideProfile && (
+          <MenuItem
+            key="view-profile"
+            onClick={() => router.push(ROUTES.MY_PROFILE)}
+          >
+            <Typography textAlign="center">Profile</Typography>
+          </MenuItem>
+        )}
         <MenuItem key="disconnect" onClick={withOnClose(onSignOut)}>
           <Typography textAlign="center">Disconnect</Typography>
         </MenuItem>

--- a/apps/website/components/templates/new-user/new-user.tsx
+++ b/apps/website/components/templates/new-user/new-user.tsx
@@ -31,6 +31,10 @@ export function NewUserTemplate() {
 
   const router = useRouter();
 
+  if (me.init) {
+    router.push(ROUTES.EXPLORE);
+  }
+
   const updateMutation = useMutation(
     'updateProfile',
     gqlAuthMethods.update_user_profile,

--- a/apps/website/components/templates/new-user/new-user.tsx
+++ b/apps/website/components/templates/new-user/new-user.tsx
@@ -31,10 +31,6 @@ export function NewUserTemplate() {
 
   const router = useRouter();
 
-  if (me.init) {
-    router.push(ROUTES.EXPLORE);
-  }
-
   const updateMutation = useMutation(
     'updateProfile',
     gqlAuthMethods.update_user_profile,

--- a/apps/website/components/templates/new-user/new-user.tsx
+++ b/apps/website/components/templates/new-user/new-user.tsx
@@ -10,6 +10,7 @@ import { Box, Snackbar, Stack, Typography } from '@mui/material';
 import { ROUTES } from '../../../constants/routes';
 import { useSnackbar } from '../../../hooks/use-snackbar';
 import { useAuth } from '../../../providers/auth';
+import { NavBarAvatar } from '../../organisms/navbar/navbar-avatar';
 import { AvatarUploadCard } from './avatar-upload-card';
 import { Form } from './form';
 import { schema, NewUserSchema, defaultValues } from './schema';
@@ -53,6 +54,9 @@ export function NewUserTemplate() {
 
   return (
     <>
+      <Stack style={{ position: 'absolute', top: '50px', right: '50px' }}>
+        <NavBarAvatar hideProfile />
+      </Stack>
       <Stack
         direction="row"
         justifyContent="space-between"

--- a/apps/website/pages/index.tsx
+++ b/apps/website/pages/index.tsx
@@ -43,15 +43,14 @@ export default function Index() {
     <>
       <LandingTemplate
         signUpButton={
-          <Link passHref href="/home">
-            <Button
-              variant="contained"
-              size="large"
-              sx={{ whiteSpace: 'nowrap', height: '56px' }}
-            >
-              {t('signUp')}
-            </Button>
-          </Link>
+          <Button
+            variant="contained"
+            size="large"
+            sx={{ whiteSpace: 'nowrap', height: '56px' }}
+            onClick={onOpenLogin}
+          >
+            {t('signUp')}
+          </Button>
         }
         theGatewayContent={theGatewayContent}
         buildAppsContent={buildAppsContent}

--- a/apps/website/pages/index.tsx
+++ b/apps/website/pages/index.tsx
@@ -10,8 +10,11 @@ import { InvestorProps } from '../components/templates/landing/investors/types';
 import { MenuListItem } from '../components/templates/landing/menu/types';
 import { ProductShowProps } from '../components/templates/landing/product-show/types';
 import { ScheduleDemoProps } from '../components/templates/landing/schedule-demo/types';
+import { useAuth } from '../providers/auth';
 
 export default function Index() {
+  const { onOpenLogin } = useAuth();
+
   const { t } = useTranslation('index');
   const menuList = t('menu', null, { returnObjects: true }) as MenuListItem[];
   const forUsersContent = t('forUsers', null, {
@@ -81,15 +84,14 @@ export default function Index() {
         menuList={menuList}
         titleDescription={t('titleDescription')}
         enterButton={
-          <Link passHref href="/new-user">
-            <Button
-              variant="contained"
-              sx={{ height: '56px', marginTop: '38px' }}
-              size="large"
-            >
-              {t('enterButtonTitle')}
-            </Button>
-          </Link>
+          <Button
+            variant="contained"
+            sx={{ height: '56px', marginTop: '38px' }}
+            size="large"
+            onClick={onOpenLogin}
+          >
+            {t('enterButtonTitle')}
+          </Button>
         }
       />
     </>

--- a/apps/website/pages/index.tsx
+++ b/apps/website/pages/index.tsx
@@ -81,7 +81,7 @@ export default function Index() {
         menuList={menuList}
         titleDescription={t('titleDescription')}
         enterButton={
-          <Link passHref href="/home">
+          <Link passHref href="/new-user">
             <Button
               variant="contained"
               sx={{ height: '56px', marginTop: '38px' }}

--- a/apps/website/providers/auth/hooks.tsx
+++ b/apps/website/providers/auth/hooks.tsx
@@ -85,5 +85,14 @@ export function useInitUser(status: AuthStatus, me: PartialDeep<SessionUser>) {
     ) {
       router.replace(ROUTES.NEW_USER);
     }
+
+    // Redirects to Explore if authenticated and user already initialized
+    if (router.pathname === ROUTES.LANDING && status === 'AUTHENTICATED') {
+      if (!me.init) {
+        router.replace(ROUTES.NEW_USER);
+      } else {
+        router.replace(ROUTES.EXPLORE);
+      }
+    }
   }, [me, router, status]);
 }


### PR DESCRIPTION
# Fix: Sign Up/Enter the Gateway Button

[Airtable Link](https://airtable.com/app1gapmC62c8UJsn/tblwmxXDTHo5Jnlpp/viwZz80FNpJNyWeTE/rec6xIT4HGmEu8a32?blocks=hide)

## Type of PR
- [✅ ] - bugfix

## Description
The buttons need to prompt the wallet to create a profile instead of opening the app.

## Solution
I changed the redirection of the button to "/new-user"
I also added a redirection on the new-user page if the user is already initiated

Ideally we would need to:
- Make the user login with his wallet
- If the wallet is already initiated redirect to the explore page
- Else redirect to new-user