### PR TITLE
Fix: Filter/List/Grid Icon

### DIFF
--- a/apps/website/components/templates/explore/tabs/daos-tab/daos-tab.tsx
+++ b/apps/website/components/templates/explore/tabs/daos-tab/daos-tab.tsx
@@ -35,7 +35,9 @@ export function DaosTab() {
           sx={{
             display: 'flex',
             alignItems: 'center',
-            justifyContent: 'center',
+            justifyContent: 'space-between',
+            mb: 4,
+            px: TOKENS.CONTAINER_PX,
           }}
         >
           <CircularProgress />

--- a/apps/website/components/templates/explore/tabs/gates-tab/gates-tab.tsx
+++ b/apps/website/components/templates/explore/tabs/gates-tab/gates-tab.tsx
@@ -34,7 +34,9 @@ export function GatesTab() {
           sx={{
             display: 'flex',
             alignItems: 'center',
-            justifyContent: 'center',
+            justifyContent: 'space-between',
+            mb: 4,
+            px: TOKENS.CONTAINER_PX,
           }}
         >
           <CircularProgress />


### PR DESCRIPTION
# Fix: Filter/List/Grid Icon

[Airtable Link](https://airtable.com/app1gapmC62c8UJsn/tblwmxXDTHo5Jnlpp/viwZz80FNpJNyWeTE/recpdIADQz2F7oSi2?blocks=hide)

## Type of PR
- [✅ ] - bugfix

## Description
From time to time the Filter and List/Grid icon goes to the center of the page. check image for reference.