### PR TITLE
fix: typo meeting code to just code

### DIFF
--- a/apps/website/components/organisms/gates/view/tasks/content/meeting_code.tsx
+++ b/apps/website/components/organisms/gates/view/tasks/content/meeting_code.tsx
@@ -9,7 +9,7 @@ const MeetingCodeContent = ({ completed, updatedAt, completeTask }) => {
     <Stack alignItems="start">
       <TextField
         fullWidth
-        placeholder="Meeting Code"
+        placeholder="Code"
         value={meetingCode}
         disabled={completed}
         onChange={(e) => setMeetingCode(e.target.value)}


### PR DESCRIPTION
# [NomenClature changed Meeting code placeholder just Code]

## Type of PR
- [x] - bugfix


## Description
<!-- Please provide an useful description for your PR, and, if possible, some screenshots-->

https://airtable.com/app1gapmC62c8UJsn/tblwmxXDTHo5Jnlpp/viw7qt8Z4mrljQiHq/recfAWo5EKTawe9YF?blocks=hide
