### PR TITLE
UI changes on Profile, Edit Profile, Edit Dao, Create Gate and Explore

### DIFF
--- a/apps/website/components/molecules/add-task/add-task-button.tsx
+++ b/apps/website/components/molecules/add-task/add-task-button.tsx
@@ -20,8 +20,12 @@ const AddTaskButton = ({
         backgroundColor: disabled
           ? 'rgba(255, 255, 255, 0.02)'
           : 'rgba(229, 229, 229, 0.08)',
+        color: 'rgba(255, 255, 255, 0.56)',
         borderRadius: '10px',
         alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: { xs: 'row', md: 'column' },
+        columnGap: '10px',
         padding: '20px 0',
         cursor: !disabled && 'pointer',
         '&:hover': {
@@ -30,8 +34,10 @@ const AddTaskButton = ({
       }}
       onClick={() => addTask()}
     >
-      <p>{icon}</p>
-      {disabled ? title + ' (Soon)' : title}
+      <span>{icon}</span>
+      <span style={{ margin: '0px 0px 5px 0px' }}>
+        {disabled ? title + ' (Soon)' : title}
+      </span>
     </Stack>
   );
 };

--- a/apps/website/components/molecules/add-task/add-task-card.tsx
+++ b/apps/website/components/molecules/add-task/add-task-card.tsx
@@ -13,12 +13,16 @@ const AddTaskCard = ({ numberOfTasks, addTask }) => {
   return (
     <Stack
       sx={{
-        padding: '50px',
+        padding: { md: '50px', xs: '20px' },
         border: '2px solid rgba(229, 229, 229, 0.08)',
         borderRadius: '10px',
       }}
     >
-      <Stack direction={'row'} alignItems={'center'} marginBottom="40px">
+      <Stack
+        direction={'row'}
+        alignItems={'center'}
+        marginBottom={{ xs: '24px', md: '40px' }}
+      >
         <CircleWithNumber
           number={numberOfTasks + 1}
           sx={(theme) => ({
@@ -33,7 +37,8 @@ const AddTaskCard = ({ numberOfTasks, addTask }) => {
       </Stack>
       <Grid
         container
-        spacing={{ xs: 0.5, md: 1 }}
+        spacing={{ xs: 1, md: 1 }}
+        direction={{ xs: 'column', md: 'row' }}
         columns={{ xs: 4, sm: 8, md: 12 }}
       >
         <Grid item xs={2} sm={4} md={4}>

--- a/apps/website/components/molecules/add-task/file-link-task/file-link-task.tsx
+++ b/apps/website/components/molecules/add-task/file-link-task/file-link-task.tsx
@@ -37,7 +37,7 @@ const FileLinkTask = ({ taskId, deleteTask }) => {
   return (
     <Stack
       sx={{
-        padding: '50px',
+        padding: { md: '50px', xs: '16px' },
         border: '2px solid rgba(229, 229, 229, 0.08)',
         borderRadius: '10px',
       }}
@@ -59,7 +59,10 @@ const FileLinkTask = ({ taskId, deleteTask }) => {
           <Typography variant="subtitle2">File &#38; Text</Typography>
           <TextField
             variant="standard"
-            sx={{ minWidth: '600px' }}
+            sx={{
+              minWidth: { md: '600px', xs: '110%' },
+              maxWidth: { xs: '100%', md: '110%' },
+            }}
             id="file-title"
             {...register(`tasks.data.${taskId}.title`)}
             error={!!errors.tasks?.data?.[taskId]?.title}
@@ -68,7 +71,13 @@ const FileLinkTask = ({ taskId, deleteTask }) => {
         </Stack>
         <DeleteIcon
           fontSize="large"
-          sx={{ position: 'absolute', right: '0', cursor: 'pointer' }}
+          sx={{
+            position: 'absolute',
+            right: '0',
+            cursor: 'pointer',
+            color: 'rgba(255, 255, 255, 0.56)',
+            fontSize: { xs: '26px' },
+          }}
           onClick={() => deleteTask(taskId)}
         />
       </Stack>
@@ -82,12 +91,23 @@ const FileLinkTask = ({ taskId, deleteTask }) => {
           {...register(`tasks.data.${taskId}.description`)}
           error={!!errors.tasks?.data?.[taskId]?.description}
           helperText={errors.tasks?.data?.[taskId]?.description?.message}
-          sx={{ marginBottom: '60px' }}
+          sx={{
+            marginBottom: '60px',
+            '& fieldset legend span': {
+              marginRight: '10px',
+            },
+          }}
         />
         {files.map((file, idx: number) => {
           return (
             <Stack gap={2} key={file.id}>
-              <Stack>
+              <Stack
+                sx={{
+                  justifyContent: 'space-between',
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                }}
+              >
                 <TextField
                   required
                   label="File Title"
@@ -106,11 +126,16 @@ const FileLinkTask = ({ taskId, deleteTask }) => {
                         ?.task_data as FileTaskDataError
                     )?.files?.[idx]?.title?.message
                   }
-                  sx={{ maxWidth: '700px' }}
+                  sx={{ minWidth: { md: '60%', xs: '80%' } }}
                 />
                 <Clear
                   fontSize="large"
-                  sx={{ position: 'absolute', right: '0', cursor: 'pointer' }}
+                  sx={{
+                    cursor: 'pointer',
+                    color: 'rgba(255, 255, 255, 0.3)',
+                    fontSize: '26px',
+                    margin: '0px 10px',
+                  }}
                   onClick={() => remove(idx)}
                 />
               </Stack>
@@ -131,6 +156,11 @@ const FileLinkTask = ({ taskId, deleteTask }) => {
                   (errors.tasks?.data?.[taskId]?.task_data as FileTaskDataError)
                     ?.files?.[idx]?.description?.message
                 }
+                sx={{
+                  '& fieldset legend span': {
+                    marginRight: '10px',
+                  },
+                }}
               />
               <TextField
                 required

--- a/apps/website/components/molecules/add-task/hold-token-task/hold-token-task.tsx
+++ b/apps/website/components/molecules/add-task/hold-token-task/hold-token-task.tsx
@@ -34,7 +34,7 @@ const HoldTokenTask = ({ taskId, deleteTask }) => {
   return (
     <Stack
       sx={{
-        padding: '50px',
+        padding: { md: '50px', xs: '16px' },
         border: '2px solid rgba(229, 229, 229, 0.08)',
         borderRadius: '10px',
       }}
@@ -56,7 +56,10 @@ const HoldTokenTask = ({ taskId, deleteTask }) => {
           <Typography variant="subtitle2">Hold Token</Typography>
           <TextField
             variant="standard"
-            sx={{ minWidth: '600px' }}
+            sx={{
+              minWidth: { md: '600px', xs: '110%' },
+              maxWidth: { md: '100%', xs: '110%' },
+            }}
             id="task-title"
             {...register(`tasks.data.${taskId}.title`)}
             error={!!errors.tasks?.data[taskId]?.title}
@@ -65,7 +68,13 @@ const HoldTokenTask = ({ taskId, deleteTask }) => {
         </Stack>
         <DeleteIcon
           fontSize="large"
-          sx={{ position: 'absolute', right: '0', cursor: 'pointer' }}
+          sx={{
+            position: 'absolute',
+            right: '0',
+            cursor: 'pointer',
+            color: 'rgba(255, 255, 255, 0.56)',
+            fontSize: { xs: '26px' },
+          }}
           onClick={() => deleteTask(taskId)}
         />
       </Stack>
@@ -85,7 +94,7 @@ const HoldTokenTask = ({ taskId, deleteTask }) => {
           <InputLabel htmlFor="chains">Chain</InputLabel>
           <Select
             id="chains"
-            sx={{ maxWidth: '50%' }}
+            sx={{ maxWidth: { md: '50%', xs: '100%' } }}
             {...register(`tasks.data.${taskId}.task_data.chain`)}
           >
             <MenuItem value="">
@@ -101,7 +110,7 @@ const HoldTokenTask = ({ taskId, deleteTask }) => {
         <TextField
           required
           label="Token address"
-          sx={{ marginTop: '15px', maxWidth: '50%' }}
+          sx={{ marginTop: '15px', maxWidth: { md: '50%', xs: '100%' } }}
           {...register(`tasks.data.${taskId}.task_data.token_address`)}
           error={
             !!(errors.tasks?.data[taskId]?.task_data as HoldTokenDataError)
@@ -115,7 +124,7 @@ const HoldTokenTask = ({ taskId, deleteTask }) => {
         <TextField
           required
           label="Quantity"
-          sx={{ marginTop: '15px', maxWidth: '50%' }}
+          sx={{ marginTop: '15px', maxWidth: { md: '50%', xs: '100%' } }}
           {...register(`tasks.data.${taskId}.task_data.quantity`)}
           error={
             !!(errors.tasks?.data[taskId]?.task_data as HoldTokenDataError)

--- a/apps/website/components/molecules/add-task/quiz-task/quiz-task.tsx
+++ b/apps/website/components/molecules/add-task/quiz-task/quiz-task.tsx
@@ -161,6 +161,11 @@ export function QuizTask({
           {...register(`tasks.data.${taskId}.description`)}
           error={!!errors.tasks?.data?.[taskId]?.description}
           helperText={errors.tasks?.data?.[taskId]?.description?.message}
+          sx={{
+            '& fieldset legend span': {
+              marginRight: '10px',
+            },
+          }}
         />
         <QuestionCreator
           questions={questions}

--- a/apps/website/components/molecules/add-task/snapshot-task/snapshot-task.tsx
+++ b/apps/website/components/molecules/add-task/snapshot-task/snapshot-task.tsx
@@ -25,7 +25,7 @@ const SnapshotTask = ({ taskId, deleteTask }) => {
   return (
     <Stack
       sx={{
-        padding: '50px',
+        padding: { md: '50px', xs: '16px' },
         border: '2px solid rgba(229, 229, 229, 0.08)',
         borderRadius: '10px',
       }}
@@ -47,7 +47,10 @@ const SnapshotTask = ({ taskId, deleteTask }) => {
           <Typography variant="subtitle2">Snapshot Governance</Typography>
           <TextField
             variant="standard"
-            sx={{ minWidth: '600px' }}
+            sx={{
+              minWidth: { md: '600px', xs: '100%' },
+              maxWidth: { md: '100%', xs: '100%' },
+            }}
             id="task-title"
             {...register(`tasks.data.${taskId}.title`)}
             error={!!errors.tasks?.data[taskId]?.title}
@@ -56,7 +59,13 @@ const SnapshotTask = ({ taskId, deleteTask }) => {
         </Stack>
         <DeleteIcon
           fontSize="large"
-          sx={{ position: 'absolute', right: '0', cursor: 'pointer' }}
+          sx={{
+            position: 'absolute',
+            right: '0',
+            cursor: 'pointer',
+            color: 'rgba(255, 255, 255, 0.56)',
+            fontSize: { xs: '26px' },
+          }}
           onClick={() => deleteTask(taskId)}
         />
       </Stack>
@@ -75,7 +84,7 @@ const SnapshotTask = ({ taskId, deleteTask }) => {
         <TextField
           required
           label="Specific proposal number"
-          sx={{ maxWidth: '50%' }}
+          sx={{ maxWidth: { md: '50%', xs: '100%' } }}
           {...register(`tasks.data.${taskId}.task_data.proposal_number`)}
           error={
             !!(errors.tasks?.data[taskId]?.task_data as SnapshotDataError)
@@ -89,7 +98,7 @@ const SnapshotTask = ({ taskId, deleteTask }) => {
         <TextField
           required
           label="Space ID"
-          sx={{ marginTop: '15px', maxWidth: '50%' }}
+          sx={{ marginTop: '15px', maxWidth: { md: '50%', xs: '100%' } }}
           {...register(`tasks.data.${taskId}.task_data.space_id`)}
           error={
             !!(errors.tasks?.data[taskId]?.task_data as SnapshotDataError)

--- a/apps/website/components/molecules/add-task/verification-task/verification-task.tsx
+++ b/apps/website/components/molecules/add-task/verification-task/verification-task.tsx
@@ -18,7 +18,7 @@ const VerificationCodeTask = ({ taskId, deleteTask }) => {
   return (
     <Stack
       sx={{
-        padding: '50px',
+        padding: { md: '50px', xs: '16px' },
         border: '2px solid rgba(229, 229, 229, 0.08)',
         borderRadius: '10px',
       }}
@@ -40,7 +40,10 @@ const VerificationCodeTask = ({ taskId, deleteTask }) => {
           <Typography variant="subtitle2">Verification Code</Typography>
           <TextField
             variant="standard"
-            sx={{ minWidth: '600px' }}
+            sx={{
+              minWidth: { md: '600px', xs: '100%' },
+              maxWidth: { md: '100%', xs: '100%' },
+            }}
             id="file-title"
             {...register(`tasks.data.${taskId}.title`)}
             error={!!errors.tasks?.data?.[taskId]?.title}

--- a/apps/website/components/molecules/form/social-links/social-link.tsx
+++ b/apps/website/components/molecules/form/social-links/social-link.tsx
@@ -75,6 +75,11 @@ export function SocialLink<TFormSchema extends FieldValues = FieldValues>({
             {...networkField.field}
             value={networkField.field.value ?? ''}
             error={!!networkField.fieldState.error}
+            sx={{
+              '& fieldset legend span': {
+                marginRight: '12px',
+              },
+            }}
           >
             {networksOptions.map((network) => (
               <MenuItem key={network.value} value={network.value}>

--- a/apps/website/components/molecules/gates-card.tsx
+++ b/apps/website/components/molecules/gates-card.tsx
@@ -5,7 +5,13 @@ import { colord } from 'colord';
 import type { PartialDeep } from 'type-fest';
 
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
-import { Avatar, CardActionArea, CardHeader, IconButton } from '@mui/material';
+import {
+  Avatar,
+  CardActionArea,
+  CardHeader,
+  IconButton,
+  Box,
+} from '@mui/material';
 import MUICard from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardMedia from '@mui/material/CardMedia';
@@ -16,8 +22,6 @@ import Typography from '@mui/material/Typography';
 import { ROUTES } from '../../constants/routes';
 import { Gates } from '../../services/graphql/types.generated';
 import { badgeProps } from '../../utils/badge-props';
-import { AvatarFile } from '../atoms/avatar-file';
-
 /* TODO: Arias and Labels */
 
 export function GatesCard({
@@ -39,27 +43,49 @@ export function GatesCard({
             {...badgeProps({ image, title })}
             sx={{ aspectRatio: '1/1' }}
           />
-
-          <CardHeader
+          <Box
             sx={{
-              pt: 2,
-              pb: 1,
-              '.MuiCardHeader-action': { alignSelf: 'unset' },
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              paddingRight: '25px',
+              paddingLeft: '16px',
             }}
-            avatar={
-              hasDao && (
-                <AvatarFile
-                  file={dao?.logo}
-                  fallback={dao?.logo_url}
-                  sx={{ width: 32, height: 32 }}
-                  aria-label={`${dao.name}'s DAO image`}
-                >
-                  {dao.name?.[0]}
-                </AvatarFile>
-              )
-            }
-            title={hasDao ? dao.name : title}
-          />
+          >
+            <CardHeader
+              sx={{
+                pt: 2,
+                pb: 1,
+                '.MuiCardHeader-action': { alignSelf: 'unset' },
+                px: 0,
+              }}
+              avatar={
+                hasDao && (
+                  <Avatar
+                    src={dao?.logo_url}
+                    sx={{ width: 32, height: 32 }}
+                    aria-label={`${dao.name}'s DAO image`}
+                  >
+                    {dao.name?.[0]}
+                  </Avatar>
+                )
+              }
+              title={hasDao ? dao.name : title}
+            />
+            <IconButton
+              aria-label="settings"
+              sx={{
+                color: (theme) =>
+                  colord(theme.palette.action.active).alpha(0.56).toRgbString(),
+                width: '14px',
+                height: '18px',
+                zIndex: 1,
+                paddingTop: '16px',
+              }}
+            >
+              <BookmarkBorderIcon sx={{ fontSize: '20px' }} />
+            </IconButton>
+          </Box>
           <CardContent sx={{ py: 1 }}>
             {hasDao && (
               <Typography gutterBottom variant="h5">
@@ -80,27 +106,23 @@ export function GatesCard({
               {description}
             </Typography>
           </CardContent>
-          <Stack direction="row" spacing={1} px={2} pt={1} pb={2}>
+          <Stack
+            direction="row"
+            sx={{
+              flexWrap: 'wrap',
+              rowGap: '8px',
+              columnGap: '8px',
+            }}
+            px={2}
+            pt={1}
+            pb={2}
+          >
             {categories.map((category) => (
               <Chip key={category} label={category} size="small" />
             ))}
           </Stack>
         </CardActionArea>
       </Link>
-
-      <IconButton
-        aria-label="settings"
-        sx={{
-          color: (theme) =>
-            colord(theme.palette.action.active).alpha(0.56).toRgbString(),
-          zIndex: 1,
-          position: 'absolute',
-          top: (theme) => theme.spacing(54),
-          right: (theme) => theme.spacing(1),
-        }}
-      >
-        <BookmarkBorderIcon />
-      </IconButton>
     </MUICard>
   );
 }

--- a/apps/website/components/organisms/create-navbar/create-navbar.tsx
+++ b/apps/website/components/organisms/create-navbar/create-navbar.tsx
@@ -13,7 +13,13 @@ export const CreateNavbar = ({ isLoading }: Props) => {
   const router = useRouter();
   return (
     <>
-      <AppBar position="fixed" sx={{ background: 'none', padding: '0 90px' }}>
+      <AppBar
+        position="fixed"
+        sx={{
+          background: 'none',
+          padding: { xs: '0 20px 0 10px', md: '0 90px' },
+        }}
+      >
         <Toolbar>
           <IconButton
             sx={{ position: 'absolute', left: 0 }}

--- a/apps/website/components/templates/create-gate/create-gate.tsx
+++ b/apps/website/components/templates/create-gate/create-gate.tsx
@@ -26,12 +26,12 @@ export function CreateGateTemplate() {
   const router = useRouter();
   const { gqlAuthMethods } = useAuth();
 
-  const { mutate: uploadImage, isLoading: isUploading } = useMutation(
+  const { mutate: uploadImage } = useMutation(
     'uploadImage',
     gqlAuthMethods.upload_image
   );
 
-  const { mutate: createGateMutation, isLoading: isCreating } = useMutation(
+  const { mutate: createGateMutation } = useMutation(
     'createGate',
     gqlAuthMethods.create_gate
   );
@@ -56,6 +56,7 @@ export function CreateGateTemplate() {
 
           createGateMutation(
             {
+              // TODO: This is Gateway's ID (temporary)
               dao_id: router.query.dao,
               title: gateData.title,
               categories: gateData.categories,
@@ -98,8 +99,12 @@ export function CreateGateTemplate() {
         [theme.breakpoints.down('sm')]: { p: '0 20px' },
       })}
     >
-      <CreateNavbar isLoading={isCreating || isUploading} />
-      <Typography component="h1" variant="h4" sx={{ margin: '40px 0 100px 0' }}>
+      <CreateNavbar isLoading={false} />
+      <Typography
+        component="h1"
+        variant="h4"
+        sx={{ margin: '40px 0 40px 0', marginBottom: { md: '100px' } }}
+      >
         Create Gate
       </Typography>
 
@@ -124,6 +129,7 @@ export function CreateGateTemplate() {
         </Box>
         <Stack
           gap={7.5}
+          mt={2}
           sx={{
             maxWidth: { xs: '100%', md: '50%', lg: '40%' },
             width: '100%',
@@ -151,13 +157,13 @@ export function CreateGateTemplate() {
           <Divider sx={{ margin: '60px 0' }} />
           <Stack
             direction="row"
-            gap={2}
+            gap={{ lg: 5, xs: 2, md: 2 }}
             sx={{
               width: '100%',
               display: { xs: 'block', md: 'flex' },
             }}
           >
-            <Box>
+            <Box sx={{ minWidth: { lg: '20%' }, marginBottom: { xs: '40px' } }}>
               <Typography component="h2" variant="h5">
                 Tasks
               </Typography>
@@ -165,7 +171,13 @@ export function CreateGateTemplate() {
                 Lorem ipsum dolor sit amet
               </Typography>
             </Box>
-            <Stack direction="column" sx={{ margin: 'auto' }}>
+            <Stack
+              direction="column"
+              sx={{
+                margin: 'auto',
+                maxWidth: { xs: '100%', md: '100%', lg: '80%' },
+              }}
+            >
               <Stack direction="column" gap={2}>
                 <FormProvider {...methods}>
                   <TaskArea />

--- a/apps/website/components/templates/create-gate/details-form.tsx
+++ b/apps/website/components/templates/create-gate/details-form.tsx
@@ -31,6 +31,11 @@ export function GateDetailsForm() {
         {...register('title')}
         error={!!errors.title}
         helperText={errors.title?.message}
+        sx={{
+          '& div fieldset legend span': {
+            marginRight: '4px',
+          },
+        }}
       />
       <CategoriesInput
         label="Categories"
@@ -42,6 +47,9 @@ export function GateDetailsForm() {
         helperText={errors.categories && 'Invalid categories added'}
         sx={{
           width: '100%',
+          '& div fieldset legend span': {
+            marginRight: '10px',
+          },
         }}
         set={(categories: string[]) => {
           setValue('categories', categories);
@@ -55,6 +63,11 @@ export function GateDetailsForm() {
         {...register('description')}
         error={!!errors.description}
         helperText={errors.description?.message}
+        sx={{
+          '& div fieldset legend span': {
+            marginRight: '12px',
+          },
+        }}
       />
       <SkillsInput
         label="Skills"
@@ -66,6 +79,9 @@ export function GateDetailsForm() {
         helperText={errors.skills && 'Invalid skills added'}
         sx={{
           width: '100%',
+          '& div fieldset legend span': {
+            marginRight: '10px',
+          },
         }}
         set={(skills: string[]) => {
           setValue('skills', skills);
@@ -84,6 +100,9 @@ export function GateDetailsForm() {
         helperText={errors.created_by && 'Invalid creator added'}
         sx={{
           width: '100%',
+          '& div fieldset legend span': {
+            marginRight: '6px',
+          },
         }}
         set={(created_by: Creator[]) => setValue('created_by', created_by)}
       />

--- a/apps/website/components/templates/create-gate/gate-image-card/gate-data.tsx
+++ b/apps/website/components/templates/create-gate/gate-image-card/gate-data.tsx
@@ -19,9 +19,11 @@ export function GateData() {
         sx={(theme) => ({
           '& .MuiCardHeader-title': {
             pb: 1,
+            wordBreak: 'break-all',
             fontSize: theme.typography.h6,
           },
           '& .MuiCardHeader-subheader': {
+            wordBreak: 'break-all',
             fontSize: theme.typography.body2,
           },
         })}

--- a/apps/website/components/templates/dao-new/dao-new.tsx
+++ b/apps/website/components/templates/dao-new/dao-new.tsx
@@ -69,7 +69,16 @@ export function NewDAOTemplate({ dao, onSubmit, isLoading }: Props) {
             <ArrowBack />
           </Avatar>
         </IconButton>
-        <LoadingButton variant="contained" type="submit" isLoading={isLoading}>
+        <LoadingButton
+          variant="contained"
+          type="submit"
+          isLoading={isLoading}
+          sx={{
+            position: 'absolute',
+            top: { xs: '26px', md: '52px' },
+            right: { xs: '26px', md: '92px' },
+          }}
+        >
           {t('submit')}
         </LoadingButton>
       </Stack>

--- a/apps/website/components/templates/dao-new/form/form.tsx
+++ b/apps/website/components/templates/dao-new/form/form.tsx
@@ -57,6 +57,11 @@ export function AboutForm({ isEdit }: Props) {
             error={!!errors.description}
             helperText={errors.description?.message}
             inputProps={{ maxLength: 200 }}
+            sx={{
+              '& div fieldset legend span': {
+                marginRight: '5px',
+              },
+            }}
           />
           <Typography sx={{ pl: 2, pb: 1 }} variant="caption">
             {descriptionRemaining}/200
@@ -78,6 +83,11 @@ export function AboutForm({ isEdit }: Props) {
                   label={t('common:fields.category')}
                   error={!!errors.categories}
                   helperText={errors.categories?.message}
+                  sx={{
+                    '& div fieldset legend span': {
+                      marginRight: '10px',
+                    },
+                  }}
                 />
               )}
               onChange={(_, data: typeof categoriesDropdown) => {

--- a/apps/website/components/templates/profile/tabs/OverviewTab.tsx
+++ b/apps/website/components/templates/profile/tabs/OverviewTab.tsx
@@ -321,6 +321,8 @@ export function OverviewTab({ user }: Props) {
                   display: 'flex',
                   flexDirection: 'row',
                   columnGap: '8px',
+                  rowGap: '8px',
+                  flexWrap: 'wrap',
                 }}
               >
                 {user.languages?.length > 0 ? (


### PR DESCRIPTION
# [PR Name]

## Type of PR

<!--(please remove unused ones)-->

BugFixes 

## Description
<!-- Please provide an useful description for your PR, and, if possible, some screenshots-->


Lorem Ipsum

<!-- If your PR is a bugfix, please provide the root cause -->

1. Bookmark is not up to place as per the design and it is overlapping with skills. 2. 
<img width="1345" alt="Screenshot 2022-07-30 at 2 18 52 AM" src="https://user-images.githubusercontent.com/98838199/181840967-e3020713-cac8-492d-ac8d-d60974e92ccc.png">

2. Increasing width when we add more skills and languages 

<img width="1437" alt="Screenshot 2022-07-30 at 2 20 47 AM" src="https://user-images.githubusercontent.com/98838199/181841202-7c9b9904-62dc-4498-a68b-b6174ec6f881.png">

3. Fix the global nav bar in Create gate and Responsiveness of half of the page ( task part left ) 

<img width="332" alt="Screenshot 2022-07-30 at 2 21 24 AM" src="https://user-images.githubusercontent.com/98838199/181841258-19bc443f-2172-4455-b9bf-3f18b2df6436.png">

4. Overlapping of the description on creating a gate 

<img width="1055" alt="Screenshot 2022-07-30 at 2 22 44 AM" src="https://user-images.githubusercontent.com/98838199/181841402-4f55f782-0f7d-4963-9e0d-9ae45c8cd4aa.png">

5. Fix overlapping of upper line and word  on Edit Dao ( Social Links ) 

<img width="547" alt="Screenshot 2022-07-30 at 2 24 41 AM" src="https://user-images.githubusercontent.com/98838199/181841640-224f2ea4-fa22-4041-8fa1-82cb0d660890.png">

6. Fix Responsiveness of Task Card 
<img width="323" alt="Screenshot_2022-08-01_at_12 12 12_AM" src="https://user-images.githubusercontent.com/98838199/182043382-15c15548-c732-48fb-ab29-b18cdc6a4c02.png">

7. Responsiveness of File and link task 
<img width="326" alt="Screenshot 2022-08-01 at 1 40 02 AM" src="https://user-images.githubusercontent.com/98838199/182043411-9f37709b-7a9f-4916-863d-a53e5a31ff3e.png">

8. Responsiveness of Hold A token

<img width="323" alt="Screenshot 2022-08-01 at 1 40 50 AM" src="https://user-images.githubusercontent.com/98838199/182043447-2193903a-6588-4798-a406-aea042104d75.png">

9. Responsiveness of Verification code and Quiz




## Checklist
<!-- Removed unused ones -->
- [] - Provided useful description for this PR
- [] - Provided the root cause of this bugfix
- [] - Tested on supported devices
