### PR TITLE
fix : shifted motion box 150px right

### DIFF
--- a/apps/website/components/templates/landing/featured/featured.tsx
+++ b/apps/website/components/templates/landing/featured/featured.tsx
@@ -134,7 +134,7 @@ export const Featured = forwardRef<
               sx={(theme) => ({
                 position: 'absolute',
                 top: '50%',
-                right: '0',
+                right: { xs: 0, lg: '-150px' },
                 maxWidth: '100%',
                 [theme.breakpoints.down('sm')]: {
                   position: 'relative',


### PR DESCRIPTION
# [PR Name]

## Type of PR

<!--(please remove unused ones)-->


- [X] - bugfix


## Description
https://airtable.com/app1gapmC62c8UJsn/tblwmxXDTHo5Jnlpp/viwd77dIfNTvzi7yw/rec3TRTCgmY9Co0Ce?blocks=hide

- [X] - Tested on supported devices
