### PR TITLE
feat: update the gatewayid feature

### DIFF
--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -33,6 +33,7 @@ export const errorMessages = {
   FAILED_QUIZ_MINIMUM_AMOUNT: `You didn't correctly answer the minimum amount requested. You will be able to retry in`,
   EMAIL_ALREADY_REGISTERED: `E-mail already registered`,
   GATEWAY_ID_ALREADY_REGISTERED: `Gateway ID already registered`,
+  GATEWAY_ID_UPDATED_RECENTLY: 'You will be able to update in [days] days.',
   ERROR_TRYING_TO_SEND_THE_CODE: `An error ocurred trying to send the code`,
   ERROR_TRYING_TO_CREATE_THE_CODE: `An error ocurred trying to create the code`,
   EXPIRED_CODE: `Expired code`,

--- a/src/services/hasura/fragments/user.gql
+++ b/src/services/hasura/fragments/user.gql
@@ -30,6 +30,7 @@ fragment protocol_user on users {
   protocolUser {
     id
     gatewayId
+    gatewayIdUpdatedAt
   }
 }
 

--- a/src/services/hasura/mutations/users.gql
+++ b/src/services/hasura/mutations/users.gql
@@ -9,3 +9,16 @@ mutation edit_user($id: uuid!, $bio: String, $name: String, $pic_id: uuid, $skil
     affected_rows
   }
 }
+
+mutation update_gateway_id($id: uuid!, $gatewayId: String) {
+    protocol {
+      updateUser(input: {
+        gatewayId: $gatewayId
+      }) {
+        id
+      }
+    }
+  update_users_by_pk(pk_columns: {id: $id}, _set: { username: $gatewayId}) {
+    ...current_user
+  }
+}


### PR DESCRIPTION
# [Edit Gateway ID]

## Type of PR

- [x] - feature

## Description
- Update the fragment to use the new field (gatewayIdUpdatedAt)
- Create a mutation to update the gatewayId on protocol and the username on dApp at the same time
- Display an alert and block the field if the gatewayId was recently updated (<30 days)
- Display dynamically how many days you need to wait to update the gatewayId again

![image](https://github.com/Gateway-DAO/ui/assets/10623930/60e95c23-32e4-4141-9864-2b2bfc16b253)

