### PR TITLE
Fix Issue #652

### DIFF
--- a/locales/en/authentication.json
+++ b/locales/en/authentication.json
@@ -58,6 +58,10 @@
     "github": {
       "title": "Github",
       "description": "Connect your account to claim credentials with repository contribution and pull requests requirements."
+    },
+    "wallet": {
+      "title": "Wallet",
+      "description": "Connect your EVM and Solana wallets to claim credentials with on-chain and offline conditions."
     }
   },
   "card-summary-title": "Your account"

--- a/src/components/features/authentication/sections/completed.tsx
+++ b/src/components/features/authentication/sections/completed.tsx
@@ -67,8 +67,8 @@ export function ConnectMoreAuthDialog({ open, onClose }: Props) {
         </Typography>
         <Stack marginTop={6} direction={{ xs: 'column', md: 'row' }} gap={2}>
           <SocialAuthCardLink
-            title={t('connected-accounts.github.title')}
-            description={t('connected-accounts.github.description')}
+            title={t('connected-accounts.wallet.title')}
+            description={t('connected-accounts.wallet.description')}
             icon={<WalletIconsTransition />}
             href={`${ROUTES.SETTINGS_ACCOUNT_MANAGEMENT}#wallets`}
           />


### PR DESCRIPTION
# Fix #652 

## Type of PR

<!--(please remove unused ones)-->
- [X] - bugfix

## Description

> Issue #652 

* created new `connected-accounts.wallet` locale string with **title** and **description**    
    ```
    "wallet": {
      "title": "Wallet",
      "description": "Connect your EVM and Solana wallets to claim credentials with on-chain and offline conditions."
    }
    ```

<img width="1846" alt="image" src="https://github.com/Gateway-DAO/ui/assets/7587923/d7e39bf0-7bd5-49d1-93d8-30582d89fbcb">

<!-- If your PR is a bugfix, please provide the root cause -->

## Checklist
<!-- Removed unused ones -->
- [X] - Provided useful description for this PR
- [X] - Provided the root cause of this bugfix
- [X] - Tested on supported devices
